### PR TITLE
Local branch

### DIFF
--- a/components/blog/blog-preview-card/BlogPreviewCard.module.css
+++ b/components/blog/blog-preview-card/BlogPreviewCard.module.css
@@ -48,7 +48,7 @@
 }
 
 @media (hover: hover) {
-  .imageContainer:hover {
+  .gridContainer:hover {
     filter: grayscale(100%);
     transition: filter 0.3s ease-out;
   }

--- a/components/layouts/navbar/Navbar.module.css
+++ b/components/layouts/navbar/Navbar.module.css
@@ -13,7 +13,7 @@
 }
 
 .navbarScrolling {
-  top: -10rem;
+  top: -11rem;
   transition: all 0.1s ease-in;
 }
 

--- a/components/quill/QuillEditor.jsx
+++ b/components/quill/QuillEditor.jsx
@@ -30,7 +30,7 @@ export default function QuillEditor({ editorContentsDelta }) {
 
   const handleChange = (content, delta, source, editor) => {
     setQuillValue(editor.getContents());
-    editorContentsDelta(editor.getContents());
+    editorContentsDelta(content);
   };
 
   return (


### PR DESCRIPTION
- fixed navbar poking in desktop screen size
- changed hover effect so the whole preview card goes grayscale
- since quill is reading and not writing, don't need the editor.getContents(), can use the HTML string and is actually faster 